### PR TITLE
Relabeling of Table 5 sheet in table output

### DIFF
--- a/Stata/plus/p/pea_tables.ado
+++ b/Stata/plus/p/pea_tables.ado
@@ -209,7 +209,7 @@ program pea_tables, rclass
 	
 	//table 5 
 	qui use `data1', clear
-	cap pea_table5 [aw=`wvar'], welfare(`onewelfare') year(`year') excel("`excelout'") age(`age') male(`male') urban(`urban') edu(`edu') industrycat4(`industrycat4') lstatus(`lstatus') empstat(`empstat') `missing'  core
+	cap pea_table5 [aw=`wvar'], welfare(`onewelfare') year(`year') excel("`excelout'") age(`age') male(`male') urban(`urban') edu(`edu') industrycat4(`industrycat4') lstatus(`lstatus') empstat(`empstat') `missing'
 	qui if _rc==0 {
 		noi dis in green "Table 5....... Done"
 		local ok = 1


### PR DESCRIPTION
The table 5 sheet was mistakenly label "A5" in the table output. Fixed.