### PR TITLE
fixing comparability issue in GIC

### DIFF
--- a/Stata/plus/p/pea_figure3b.ado
+++ b/Stata/plus/p/pea_figure3b.ado
@@ -52,7 +52,6 @@ program pea_figure3b, rclass
 	di "`spellsnew'"
 	// Prepare spells
 	tokenize "`spells'", parse(";")	
-	local comparability comparability
 	// Comparability
 	local one = 1
 	if "`comparability'" ~= "" {


### PR DESCRIPTION
Fixing bug in Figure 3b, allowing for alternative comparability variables.